### PR TITLE
[WIP] Allow cells to be explicitly ignored by nbinclude

### DIFF
--- a/src/NBInclude.jl
+++ b/src/NBInclude.jl
@@ -82,7 +82,9 @@ function nbinclude(path::AbstractString; renumber::Bool=false)
     lang == "julia" || error("notebook is for unregognized language $lang")
 
     shell_or_help = r"^\s*[;?]" # pattern for shell command or help
-
+    ignore_marker = "nbi"
+    explicit_ignore = r"^\s#\s*\!$(ignore_marker)" # skip cell if it starts with "#!nbi"
+    
     ret = nothing
     counter = 0 # keep our own cell counter to handle un-executed notebooks.
     for cell in nb["cells"]
@@ -91,6 +93,8 @@ function nbinclude(path::AbstractString; renumber::Bool=false)
             isempty(strip(s)) && continue # Jupyter doesn't number empty cells
             counter += 1
             ismatch(shell_or_help, s) && continue
+            ismatch(explicit_ignore, s) && continue
+
             cellnum = renumber ? string(counter) :
                       cell["execution_count"] == nothing ? string('+',counter) :
                       string(cell["execution_count"])


### PR DESCRIPTION
## Context/Motivation:

I am looking to smooth the following flow when writing pedagogical notebooks: in one notebook, develop an idea complete with visualizations, digressions, benchmarks, and explorations, and then for the next idea start another notebook which builds on the previous but only nbinclude's the "important stuff"
## Caveats / Improvements:
- not tested
- notation may not be aesthetically pleasing to all 
- TODO: Allow the ability to exclude on a line by line basis
