### PR TITLE
Update Travis Config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
-  - 0.7
   - 1.0
+  - 1.1 
+  - 1.2
   - nightly
 notifications:
   email: false
+matrix:
+  allow_failures:
+  - julia: nightly


### PR DESCRIPTION
Allow nightly failures, and drop 0.6 and 0.7 in favor of 1.1 and 1.2

